### PR TITLE
Habilitar opciones de IntelliJ para generar el javadoc en UTF8

### DIFF
--- a/centro-medico-v2/.idea/misc.xml
+++ b/centro-medico-v2/.idea/misc.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="JavadocGenerationManager">
     <option name="OUTPUT_DIRECTORY" value="$PROJECT_DIR$/../javadoc" />
+    <option name="OTHER_OPTIONS" value="-encoding utf8 -docencoding utf8 -charset utf8" />
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />


### PR DESCRIPTION
Se agregan las opciones de proyecto para que genere el javadoc en UTF8 y no tener problemas de encoding ni tener que escapar las entidades HTML

Solución aplicada: https://stackoverflow.com/a/13325904