### PR TITLE
Implementar `guardarEnfermera` usando un `java.util.Set`

### DIFF
--- a/centro-medico-v2/src/Main.java
+++ b/centro-medico-v2/src/Main.java
@@ -1,5 +1,6 @@
 import logica.IGeneradorDeReportes;
 import logica.impl.GeneradorDeReportes;
+import modelo.impl.Enfermera;
 import modelo.impl.Medico;
 import persistencia.IObjetoDeAcessoADatos;
 import persistencia.impl.ObjetoDeAccesoADatos;
@@ -7,6 +8,7 @@ import persistencia.impl.ObjetoDeAccesoADatos;
 public class Main {
     public static void main(String[] args) {
         probarBaseDeDatosConMedicos();
+        probarBaseDeDatosConEnfermeras();
     }
 
     public static void probarBaseDeDatosConMedicos(){
@@ -30,5 +32,10 @@ public class Main {
         //En esta prueba esperamos que no se puedan guardar registros duplicados.
         IObjetoDeAcessoADatos baseDeDatos = new ObjetoDeAccesoADatos();
 
+        Enfermera enfermera1 = new Enfermera("456", "Enfermera", "655-555-555");
+        Enfermera enfermera2 = new Enfermera("456", "Enfermera", "655-555-555");
+
+        System.out.println(baseDeDatos.guardarEnfermera(enfermera1));
+        System.out.println(baseDeDatos.guardarEnfermera(enfermera2));
     }
 }

--- a/centro-medico-v2/src/modelo/impl/Enfermera.java
+++ b/centro-medico-v2/src/modelo/impl/Enfermera.java
@@ -2,8 +2,23 @@ package modelo.impl;
 
 import modelo.ProfesionalDeLaSalud;
 
+import java.util.Objects;
+
 public class Enfermera extends ProfesionalDeLaSalud {
     public Enfermera(String dni, String nombre, String telefono) {
         super(dni, nombre, telefono);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Enfermera)) return false;
+        if (!super.equals(o)) return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode());
     }
 }

--- a/centro-medico-v2/src/persistencia/impl/ObjetoDeAccesoADatos.java
+++ b/centro-medico-v2/src/persistencia/impl/ObjetoDeAccesoADatos.java
@@ -5,13 +5,16 @@ import modelo.impl.Medico;
 import modelo.impl.Paciente;
 import persistencia.IObjetoDeAcessoADatos;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 public class ObjetoDeAccesoADatos implements IObjetoDeAcessoADatos {
 
     private List<Medico> medicos = new ArrayList<>();
     private List<Paciente> pacientes = new ArrayList<>();
-    private Set<Enfermera> enfermeras = new HashSet<>();
+    private Set<Enfermera> enfermeras = new LinkedHashSet<>();
 
 
     @Override
@@ -51,8 +54,7 @@ public class ObjetoDeAccesoADatos implements IObjetoDeAcessoADatos {
 
     @Override
     public boolean guardarEnfermera(Enfermera e) {
-        //TODO: Implementar usando Set en vez de List
-        return false;
+        return this.enfermeras.add(e);
     }
 
     @Override


### PR DESCRIPTION
- Se implementa el método `guardarEnfermera` del DAO usando `java.util.Set#add`. `java.util.Set#add` nos devuelve si se agregó o no a la colección en la propia implementación del método por lo que no se necesita de ningúna otra comprobación para discriminar por duplicados.

- Se cambia de `HashSet` a `LinkedHashSet` para tener un acceso secuencial dentro de la colección